### PR TITLE
fix(test): align profile-updater test expectations with actual output

### DIFF
--- a/test/profile-updater/profile-updater.test.ts
+++ b/test/profile-updater/profile-updater.test.ts
@@ -18,45 +18,37 @@ describe('Profile Updater', () => {
   describe('generateProfileDescription', () => {
     it('should generate correct profile description with formatted count', () => {
       const result = generateProfileDescription(1234567);
-      const expected = `A bot which tells you how much profanity a user has poasted.
+      const expected = `Tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (it may take me a few minutes to respond).
 
-1,234,567 total profanities counted, you pottymouths!
+1,234,567 total profanities counted, you pottymouths!`;
 
-Simply tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (might take me a few minutes to respond).`;
-      
       expect(result).toBe(expected);
     });
 
     it('should handle zero count', () => {
       const result = generateProfileDescription(0);
-      const expected = `A bot which tells you how much profanity a user has poasted.
+      const expected = `Tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (it may take me a few minutes to respond).
 
-0 total profanities counted, you pottymouths!
+0 total profanities counted, you pottymouths!`;
 
-Simply tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (might take me a few minutes to respond).`;
-      
       expect(result).toBe(expected);
     });
 
     it('should handle single digit count', () => {
       const result = generateProfileDescription(5);
-      const expected = `A bot which tells you how much profanity a user has poasted.
+      const expected = `Tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (it may take me a few minutes to respond).
 
-5 total profanities counted, you pottymouths!
+5 total profanities counted, you pottymouths!`;
 
-Simply tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (might take me a few minutes to respond).`;
-      
       expect(result).toBe(expected);
     });
 
     it('should handle large numbers', () => {
       const result = generateProfileDescription(999999999);
-      const expected = `A bot which tells you how much profanity a user has poasted.
+      const expected = `Tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (it may take me a few minutes to respond).
 
-999,999,999 total profanities counted, you pottymouths!
+999,999,999 total profanities counted, you pottymouths!`;
 
-Simply tag me and I will respond telling you how much a profanity you (or the user you're replying to) has used in the last year (might take me a few minutes to respond).`;
-      
       expect(result).toBe(expected);
     });
   });


### PR DESCRIPTION
## Summary

Small fix found while reviewing the codebase to get repo activity going again.

- `test/profile-updater/profile-updater.test.ts` and `src/services/profile-updater.ts` were both added in the same commit ([1abf646](https://github.com/himynameisdave/bsky-profanity-counter/commit/1abf64625b83a776682638fc87ac227d58ff3f64)), but the test's expected strings never actually matched what `generateProfileDescription()` produces (different intro sentence, different paragraph order, "poasted" typo, etc.). `pnpm test` has been failing on this suite ever since.
- Updated the 4 expected strings in the test to match the real template literal output from `generateProfileDescription`. No production/runtime behavior changes — this only fixes the test assertions, so the bot's actual live profile description text is untouched.

Verified the mismatch and the fix by extracting the exact `formatNumber`/`generateProfileDescription` logic into a standalone Node script and diffing the actual vs. previously-expected output byte-for-byte (couldn't run `pnpm test` directly in this sandbox — outbound access to the npm registry is blocked here — but the string comparison is deterministic and doesn't depend on any dependency).

## Test plan

- [x] Manually confirmed the previous expected strings never equaled the actual `generateProfileDescription()` output (verified via a standalone script reproducing the exact logic)
- [x] Confirmed the new expected strings are byte-for-byte identical to the real implementation's template literal for counts `1234567`, `0`, `5`, and `999999999`
- [ ] `pnpm test` (please confirm green in CI/locally — this sandbox couldn't reach the npm registry to install deps and run it directly)

## Note

Also noticed GitHub reported 18 Dependabot alerts (1 critical, 4 high, 10 moderate, 3 low) on `main` when pushing this branch. Didn't touch dependencies here since I couldn't verify an upgrade end-to-end in this sandbox (registry access blocked), but that's probably worth a follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WCeFvT4S4Jhm6BxKogbhig)_