### PR TITLE
🧵 Thread bot replies under the real conversation root

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -52,11 +52,8 @@ async function processMention(agent: BskyAgent, mention: Mention) {
 
       if (mentionPost) {
         // Reply to the mention with the analysis results
-        const reply = (await bsky.replyToPost(
-          agent,
-          { uri: mentionPost.uri, cid: mentionPost.cid },
-          responseMessage,
-        )) as { uri?: string; cid?: string } | undefined;
+        const posted = await bsky.replyToPost(agent, mentionPost, responseMessage);
+        const reply = posted as { uri?: string; cid?: string } | undefined;
 
         // Extract the reply post ID and URL
         const replyPostId = reply?.uri?.split('/').pop() || '';
@@ -124,11 +121,8 @@ async function processMention(agent: BskyAgent, mention: Mention) {
 
         if (mentionPost) {
           // Reply to the mention with the analysis results
-          const reply = (await bsky.replyToPost(
-            agent,
-            { uri: mentionPost.uri, cid: mentionPost.cid },
-            responseMessage,
-          )) as { uri?: string; cid?: string } | undefined;
+          const posted = await bsky.replyToPost(agent, mentionPost, responseMessage);
+          const reply = posted as { uri?: string; cid?: string } | undefined;
 
           // Extract the reply post ID and URL
           const replyPostId = reply?.uri?.split('/').pop() || '';

--- a/src/services/bluesky.ts
+++ b/src/services/bluesky.ts
@@ -188,6 +188,42 @@ export const getUserPosts = async (
   return allPosts;
 };
 
+// A reference to a post, as used in a reply's parent/root
+export type PostRef = { uri: string; cid: string };
+
+// A post as returned by getPost(): a reference to it, plus its record
+export type PostRecord = PostRef & { value?: unknown };
+
+// The shape we care about within a post record: where its thread starts
+type PostValue = { reply?: { root?: { uri?: unknown; cid?: unknown } } };
+
+/**
+ * Works out the parent and root refs to use when replying to a post.
+ *
+ * Per the atproto spec, every reply in a thread carries the *thread's* root,
+ * not just the post it is replying to. If the post we're replying to is itself
+ * a reply, its record already points at the real root, so we reuse that.
+ * If it's a top-level post, then it is the root.
+ *
+ * Getting this wrong forks the conversation: the AppView groups thread views by
+ * root, so a reply with the wrong root renders orphaned from the conversation
+ * the person who tagged us is actually looking at.
+ */
+export const getReplyRefs = (replyTo: PostRecord): { parent: PostRef; root: PostRef } => {
+  const parent: PostRef = { uri: replyTo.uri, cid: replyTo.cid };
+
+  // Post records are loosely typed, so narrow before reading the thread root
+  const record = replyTo.value as PostValue | undefined;
+  const root = record?.reply?.root;
+
+  if (typeof root?.uri === 'string' && typeof root.cid === 'string') {
+    return { parent, root: { uri: root.uri, cid: root.cid } };
+  }
+
+  // No root on the record: the post we're replying to is the top of the thread
+  return { parent, root: parent };
+};
+
 // Get a post by URI
 export const getPost = async (agent: BskyAgent, uri: string) => {
   try {
@@ -209,14 +245,10 @@ export const getPost = async (agent: BskyAgent, uri: string) => {
   }
 };
 
-// Reply to a post
-export const replyToPost = async (
-  agent: BskyAgent,
-  replyTo: { uri: string; cid: string },
-  text: string,
-  rootUri?: string,
-  rootCid?: string,
-) => {
+// Reply to a post.
+// `replyTo` should be the post record as returned by getPost(), so that the
+// thread root can be derived from it (see getReplyRefs).
+export const replyToPost = async (agent: BskyAgent, replyTo: PostRecord, text: string) => {
   logger.info(`🗣️ Replying to ${replyTo.uri}...`);
 
   // Create facets for mentions in the text
@@ -255,12 +287,8 @@ export const replyToPost = async (
     }
   }
 
-  // Set up the reply structure. If rootUri and rootCid are provided, use them for
-  // the root; otherwise use the parent (for direct replies to top-level posts).
-  const reply = {
-    parent: replyTo,
-    root: rootUri && rootCid ? { uri: rootUri, cid: rootCid } : replyTo,
-  };
+  // Set up the reply structure, keeping the bot's reply in the same thread
+  const reply = getReplyRefs(replyTo);
 
   // Post with facets if any were created
   return agent.post({

--- a/src/services/self-targeting.ts
+++ b/src/services/self-targeting.ts
@@ -40,11 +40,8 @@ export async function handleSelfTargeting(agent: BskyAgent, mention: Mention): P
     const randomResponse = getRandomResponse();
 
     // Reply to the mention with the whimsical response
-    const reply = (await bsky.replyToPost(
-      agent,
-      { uri: mentionPost.uri, cid: mentionPost.cid },
-      randomResponse,
-    )) as { uri?: string; cid?: string } | undefined;
+    const posted = await bsky.replyToPost(agent, mentionPost, randomResponse);
+    const reply = posted as { uri?: string; cid?: string } | undefined;
 
     // Extract the reply post ID and URL
     const replyPostId = reply?.uri?.split('/').pop() || '';

--- a/test/bluesky.test.ts
+++ b/test/bluesky.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { BskyAgent } from '@atproto/api';
+import { getReplyRefs, replyToPost } from '../src/services/bluesky.js';
+
+// bluesky.js throws at import time when credentials are missing, and hoisted
+// callbacks run before any import, so this is the spot to make sure it has some
+vi.hoisted(() => {
+  process.env.BLUESKY_IDENTIFIER ??= 'test.bot';
+  process.env.BLUESKY_PASSWORD ??= 'test-password';
+});
+
+vi.mock(import('../src/services/logger.js'), () => ({
+  info: vi.fn<() => void>(),
+  success: vi.fn<() => void>(),
+  warn: vi.fn<() => void>(),
+  error: vi.fn<() => void>(),
+}));
+
+// The post which mentions the bot, ie. the one we reply to
+const MENTION = {
+  uri: 'at://did:plc:mentioner/app.bsky.feed.post/mention',
+  cid: 'bafy-mention',
+};
+
+// The post which started the thread the mention lives in
+const THREAD_ROOT = {
+  uri: 'at://did:plc:original/app.bsky.feed.post/root',
+  cid: 'bafy-root',
+};
+
+// The post the mention is directly replying to, somewhere below the root
+const THREAD_PARENT = {
+  uri: 'at://did:plc:someone/app.bsky.feed.post/parent',
+  cid: 'bafy-parent',
+};
+
+// What getPost() hands back for a mention nested inside a thread
+const nestedMentionPost = () => ({
+  ...MENTION,
+  value: {
+    text: '@profanity.accountant how bad is this person?',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    reply: {
+      root: THREAD_ROOT,
+      parent: THREAD_PARENT,
+    },
+  },
+});
+
+// What getPost() hands back for a mention which is itself a top-level post
+const topLevelMentionPost = () => ({
+  ...MENTION,
+  value: {
+    text: '@profanity.accountant how bad am I?',
+    createdAt: '2025-01-01T00:00:00.000Z',
+  },
+});
+
+const createFakeAgent = () => ({
+  post: vi.fn<() => void>(),
+  resolveHandle: vi.fn<() => void>(),
+});
+
+describe('Reply ref derivation', () => {
+  it('should use the thread root from the record when the post is itself a reply', () => {
+    const refs = getReplyRefs(nestedMentionPost());
+
+    expect(refs.parent).toStrictEqual(MENTION);
+    expect(refs.root).toStrictEqual(THREAD_ROOT);
+  });
+
+  it('should not mistake the post being replied to for the thread root', () => {
+    const refs = getReplyRefs(nestedMentionPost());
+
+    expect(refs.root).not.toStrictEqual(THREAD_PARENT);
+    expect(refs.root).not.toStrictEqual(MENTION);
+  });
+
+  it('should use the post itself as the root when it is a top-level post', () => {
+    const refs = getReplyRefs(topLevelMentionPost());
+
+    expect(refs.parent).toStrictEqual(MENTION);
+    expect(refs.root).toStrictEqual(MENTION);
+  });
+
+  it('should use the post itself as the root when there is no record', () => {
+    const refs = getReplyRefs(MENTION);
+
+    expect(refs.parent).toStrictEqual(MENTION);
+    expect(refs.root).toStrictEqual(MENTION);
+  });
+
+  it('should use the post itself as the root when the root ref is incomplete', () => {
+    const refs = getReplyRefs({
+      ...MENTION,
+      value: {
+        reply: {
+          root: { uri: THREAD_ROOT.uri },
+          parent: THREAD_PARENT,
+        },
+      },
+    });
+
+    expect(refs.root).toStrictEqual(MENTION);
+  });
+});
+
+describe('Replying to a mention', () => {
+  it('should thread the reply under the original conversation root', async () => {
+    const agent = createFakeAgent();
+
+    await replyToPost(agent as unknown as BskyAgent, nestedMentionPost(), 'Beep boop.');
+
+    expect(agent.post).toHaveBeenCalledWith({
+      text: 'Beep boop.',
+      facets: undefined,
+      reply: {
+        parent: MENTION,
+        root: THREAD_ROOT,
+      },
+    });
+  });
+
+  it('should use the mention as the root when it is a top-level post', async () => {
+    const agent = createFakeAgent();
+
+    await replyToPost(agent as unknown as BskyAgent, topLevelMentionPost(), 'Beep boop.');
+
+    expect(agent.post).toHaveBeenCalledWith({
+      text: 'Beep boop.',
+      facets: undefined,
+      reply: {
+        parent: MENTION,
+        root: MENTION,
+      },
+    });
+  });
+});

--- a/test/self-targeting.test.ts
+++ b/test/self-targeting.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import type { BskyAgent } from '@atproto/api';
+import type { Mention } from '@prisma/client';
+import * as bsky from '../src/services/bluesky.js';
+import { handleSelfTargeting } from '../src/services/self-targeting.js';
+
+vi.mock(import('../src/services/database.js'), () => ({
+  markMentionAsDone: vi.fn<() => void>(),
+}));
+
+vi.mock(import('../src/services/bluesky.js'), () => ({
+  getPost: vi.fn<() => void>(),
+  replyToPost: vi.fn<() => void>(),
+}));
+
+vi.mock(import('../src/services/logger.js'), () => ({
+  info: vi.fn<() => void>(),
+  success: vi.fn<() => void>(),
+  warn: vi.fn<() => void>(),
+  error: vi.fn<() => void>(),
+}));
+
+// The mocked module hands back plain mock functions
+const getPostMock = bsky.getPost as unknown as Mock;
+const replyToPostMock = bsky.replyToPost as unknown as Mock;
+
+// A mention of the bot which lives partway down someone else's thread
+const MENTION_POST = {
+  uri: 'at://did:plc:bot/app.bsky.feed.post/mention',
+  cid: 'bafy-mention',
+  value: {
+    text: '@profanity.accountant analyse yourself',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    reply: {
+      root: {
+        uri: 'at://did:plc:original/app.bsky.feed.post/root',
+        cid: 'bafy-root',
+      },
+      parent: {
+        uri: 'at://did:plc:someone/app.bsky.feed.post/parent',
+        cid: 'bafy-parent',
+      },
+    },
+  },
+};
+
+// What our own reply comes back as once posted
+const OUR_REPLY = {
+  uri: 'at://did:plc:bot/app.bsky.feed.post/ourreply',
+  cid: 'bafy-ourreply',
+};
+
+const mention = {
+  id: 'mention-id',
+  userHandle: 'profanity.accountant',
+  postUrl: MENTION_POST.uri,
+} as Mention;
+
+describe('Self-targeting replies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPostMock.mockResolvedValue(MENTION_POST);
+    replyToPostMock.mockResolvedValue(OUR_REPLY);
+  });
+
+  it('should pass the whole mention post through to replyToPost', async () => {
+    await handleSelfTargeting({} as BskyAgent, mention);
+
+    expect(replyToPostMock).toHaveBeenCalledOnce();
+
+    // The record has to come along for the ride, otherwise replyToPost cannot
+    // work out the thread root and our reply forks the conversation
+    const [[, replyTo]] = replyToPostMock.mock.calls;
+    expect(replyTo).toStrictEqual(MENTION_POST);
+  });
+});


### PR DESCRIPTION
Fixes #7.

## The bug

`replyToPost()` accepted optional `rootUri`/`rootCid`, but neither call site ever passed them, so `reply.root` always fell back to the mention post itself. That's only correct when the mention is a top-level post — which is the opposite of the bot's main use case. When someone tags the bot from inside a conversation, the AppView groups the thread by `root`, so our reply forked into its own thread and the person who summoned the bot might never see it.

## The fix

Rather than adding two more optional args that call sites can forget, `replyToPost()` now takes the post record as returned by `getPost()` (which we already fetch at every call site) and derives the refs itself:

- New exported `getReplyRefs(replyTo)` returns `{ parent, root }`. The post we're replying to is always the parent; the root comes from that post's own `reply.root` when it has one, and falls back to the post itself when it doesn't (top-level mention) or when the ref is incomplete.
- `replyToPost()` calls it internally, so there's no way for a call site to drop the root on the floor. The `any`-typed reply object is gone too.
- `src/analysis.ts` (both branches) and `src/services/self-targeting.ts` now pass `mentionPost` straight through instead of stripping it to `{ uri, cid }`.

I skipped step 2 of the issue (persisting root uri/cid on the `Mention` row). It would need a schema change, and since the reply path already fetches the mention post immediately before replying, deriving the root there needs no extra API call and no migration. Happy to add it if you'd rather have it stored.

## Tests

- `test/bluesky.test.ts` — `getReplyRefs` with and without `reply.root` on the record, plus a missing record and a half-populated root ref; and `replyToPost` asserting the exact `reply` payload handed to `agent.post()` for both thread shapes.
- `test/self-targeting.test.ts` — guards the call site, asserting the full mention post (record included) reaches `replyToPost`.

⚠️ I could not execute the suite in this session: `registry.npmjs.org` is outside this environment's network egress allowlist (`403 host_not_allowed`), so `pnpm install` cannot fetch the deps. I verified the derivation logic by running the five ref cases against a type-stripped copy of `getReplyRefs` under plain node, and the rest is reviewed by hand — please run `pnpm test` locally before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ki1Hsx8tGRhomdDZfTbn9B)_