### PR TITLE
🐛 Stop losing and double-answering mentions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,10 @@ model Mention {
   // Relation to Analysis if needed
   analysisId    String?
   analysis      Analysis?     @relation(fields: [analysisId], references: [id])
+
+  // One row per mentioning post, so replaying a notification can't create a
+  // duplicate (and get the user two replies)
+  @@unique([postId])
 }
 
 model Analysis {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,15 +37,17 @@ async function main() {
 
     // STEP 1: Get recent mentions and store them in the database
     logger.info('🗣️ Getting unread mentions from Bluesky...');
-    const mentions = await getMentions(agent);
+    const { mentions, latestIndexedAt } = await getMentions(agent);
 
     if (mentions.length > 0) {
       logger.info(`✅ Found ${mentions.length} unread mentions to process`);
-      //  First thing we do is store the mentions in the database
-      await storeMentions(agent, mentions);
     } else {
       logger.info('🫤 No new mentions to store, going to process some analysis');
     }
+
+    //  First thing we do is store the mentions in the database, then move the
+    //  read cursor up to the batch we just fetched
+    await storeMentions(agent, mentions, latestIndexedAt);
 
     // Now we check for unanalyzed mentions and process them
     await checkAndProcessMentions(agent);

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -1,6 +1,7 @@
 import type { BskyAgent } from '@atproto/api';
 import * as bsky from './services/bluesky.js';
 import * as db from './services/database.js';
+import * as logger from './services/logger.js';
 import type { Notification } from './types.js';
 
 // Notification records are loosely typed, so narrow before reading the reply parent
@@ -74,32 +75,82 @@ async function getParentAuthorHandle(
 /**
  * Takes each notification from Bluesky, converts it to our Mention format,
  * and stores it in the database.
+ *
+ * `latestIndexedAt` is the newest notification in the batch we fetched (see
+ * bsky.getMentions). Once everything is safely stored we mark notifications as
+ * read up to that point — never up to "now", which would swallow anything that
+ * arrived while this run was in flight.
  */
-export default async function storeMentions(agent: BskyAgent, mentions: Notification[]) {
-  await Promise.all(
-    mentions.map(async (mention) => {
-      try {
-        // Start with basic mention info
-        const mentionData = notificationToMention(mention);
-
-        // If this is a reply, we analyze the parent post author instead
-        if (mentionData.isReply) {
-          const parentHandle = await getParentAuthorHandle(agent, mention);
-          if (parentHandle) {
-            mentionData.userHandle = parentHandle;
-          }
-        }
-
-        // Store in database
-        await db.storeMention(mentionData);
-      } catch {
-        // A single bad mention shouldn't stop the rest from being stored
-      }
-    }),
-  );
-
-  // After storing all mentions, mark notifications as read
-  if (mentions.length > 0) {
-    await bsky.markNotificationsAsRead(agent);
+export default async function storeMentions(
+  agent: BskyAgent,
+  mentions: Notification[],
+  latestIndexedAt: string | null,
+) {
+  if (!latestIndexedAt) {
+    // Nothing was fetched, so there's no read cursor to advance
+    return;
   }
+
+  // Process mentions sequentially, oldest first: the read cursor can only move
+  // past a mention once that mention is actually in the database
+  const ordered = mentions.toSorted((a, b) => Date.parse(a.indexedAt) - Date.parse(b.indexedAt));
+
+  let lastStoredIndexedAt: string | null = null;
+  let firstFailure: Notification | null = null;
+
+  for (const mention of ordered) {
+    try {
+      // Start with basic mention info
+      const mentionData = notificationToMention(mention);
+
+      // If this is a reply, we analyze the parent post author instead
+      if (mentionData.isReply) {
+        // Deliberately sequential: each mention gates how far the read cursor moves
+        // oxlint-disable-next-line no-await-in-loop
+        const parentHandle = await getParentAuthorHandle(agent, mention);
+        if (parentHandle) {
+          mentionData.userHandle = parentHandle;
+        }
+      }
+
+      // Store in database (an upsert, so replaying a notification is a no-op)
+      // oxlint-disable-next-line no-await-in-loop
+      await db.storeMention(mentionData);
+
+      if (!firstFailure) {
+        lastStoredIndexedAt = mention.indexedAt;
+      }
+    } catch (error) {
+      // A single bad mention shouldn't stop the rest from being stored, but it
+      // does stop the read cursor from moving past it
+      logger.error(`❌ Error storing mention ${mention.uri}\n\t- ${error}`);
+
+      firstFailure ??= mention;
+    }
+  }
+
+  // Don't move the cursor onto (or past) a mention we failed to store, otherwise
+  // it gets marked read and is never retried
+  if (
+    firstFailure &&
+    lastStoredIndexedAt &&
+    Date.parse(lastStoredIndexedAt) >= Date.parse(firstFailure.indexedAt)
+  ) {
+    lastStoredIndexedAt = null;
+  }
+
+  const seenAt = firstFailure ? lastStoredIndexedAt : latestIndexedAt;
+
+  if (firstFailure) {
+    logger.warn(
+      `⚠️ Leaving notifications from ${firstFailure.indexedAt} onwards unread so they're retried next run`,
+    );
+  }
+
+  if (!seenAt) {
+    logger.warn('🚧 Not marking any notifications as read this run');
+    return;
+  }
+
+  await bsky.markNotificationsAsRead(agent, seenAt);
 }

--- a/src/services/bluesky.ts
+++ b/src/services/bluesky.ts
@@ -100,10 +100,10 @@ export const getMentions = async (agent: BskyAgent): Promise<MentionsBatch> => {
         `🕒 Stopping after page #${page}: reached notifications older than ${NOTIFICATION_LOOKBACK_DAYS} days`,
       );
       keepPaging = false;
-    } else if (!response.data.cursor) {
-      keepPaging = false;
+    } else if (response.data.cursor) {
+      ({ cursor } = response.data);
     } else {
-      cursor = response.data.cursor;
+      keepPaging = false;
     }
   }
 

--- a/src/services/bluesky.ts
+++ b/src/services/bluesky.ts
@@ -29,54 +29,106 @@ export const createAgent = async (): Promise<BskyAgent> => {
   return agent;
 };
 
-// Get notifications where the bot is mentioned
-export const getMentions = async (agent: BskyAgent) => {
-  const allNotifications: Notification[] = [];
+// Most pages of notifications we're willing to walk in a single run
+const MAX_NOTIFICATION_PAGES = 25;
+// Belt-and-suspenders cutoff, in case we never hit a fully-read page
+const NOTIFICATION_LOOKBACK_DAYS = 7;
+const NOTIFICATIONS_PER_PAGE = 100;
 
-  logger.info('🔍 Getting notifications...');
-
-  // Iterate through all pages of notifications
-  // Recursive function to fetch notifications page by page
-  const fetchNotificationsPage = async (currentCursor?: string): Promise<void> => {
-    const response = await agent.listNotifications({
-      limit: 100,
-      cursor: currentCursor,
-    });
-
-    allNotifications.push(...response.data.notifications);
-
-    // Base case: no more pages to fetch
-    if (!response.data.cursor) {
-      return;
-    }
-
-    // Recursive case: fetch the next page
-    return fetchNotificationsPage(response.data.cursor);
-  };
-
-  // Start the recursive fetching process
-  await fetchNotificationsPage();
-
-  if (allNotifications.length > 0) {
-    logger.info(`📥 Found ${allNotifications.length} notifications`);
-  } else {
-    logger.info('❌ No notifications found');
-    return [];
-  }
-
-  // Filter for mentions in replies that we haven't processed yet
-  const unreadMentions = allNotifications.filter(
-    (notification) => notification.reason === 'mention' && !notification.isRead,
-  );
-
-  logger.info(`📤 Found ${unreadMentions.length} unread mentions`);
-
-  return unreadMentions;
+export type MentionsBatch = {
+  // The unread mentions we still owe a reply to
+  mentions: Notification[];
+  // The `indexedAt` of the newest notification in the batch we actually fetched.
+  // This is what `seenAt` should be derived from — see markNotificationsAsRead.
+  // `null` when there was nothing to fetch.
+  latestIndexedAt: string | null;
 };
 
-//  Marks all notifications as read
-export const markNotificationsAsRead = async (agent: BskyAgent) => {
-  const seenAt = new Date().toISOString();
+const toTime = (indexedAt: string) => Date.parse(indexedAt);
+
+// Get notifications where the bot is mentioned
+export const getMentions = async (agent: BskyAgent): Promise<MentionsBatch> => {
+  logger.info('🔍 Getting notifications...');
+
+  const cutoff = Date.now() - NOTIFICATION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+  const mentions: Notification[] = [];
+  let latestIndexedAt: string | null = null;
+  let fetchedCount = 0;
+  let cursor: string | undefined;
+  let page = 0;
+  let keepPaging = true;
+
+  // Notifications come back newest-first, so we only page far enough back to
+  // cover everything that is still unread — not the account's whole history.
+  while (keepPaging && page < MAX_NOTIFICATION_PAGES) {
+    page++;
+
+    // Pagination is inherently sequential: each request needs the previous cursor
+    // oxlint-disable-next-line no-await-in-loop
+    const response = await agent.listNotifications({
+      limit: NOTIFICATIONS_PER_PAGE,
+      cursor,
+    });
+
+    const { notifications } = response.data;
+
+    if (notifications.length === 0) {
+      keepPaging = false;
+      break;
+    }
+
+    fetchedCount += notifications.length;
+
+    for (const notification of notifications) {
+      if (!latestIndexedAt || toTime(notification.indexedAt) > toTime(latestIndexedAt)) {
+        latestIndexedAt = notification.indexedAt;
+      }
+
+      if (notification.reason === 'mention' && !notification.isRead) {
+        mentions.push(notification);
+      }
+    }
+
+    const oldestOnPage = notifications[notifications.length - 1];
+
+    if (notifications.every((notification) => notification.isRead)) {
+      // Everything on this page has been read, so everything older has been too
+      logger.info(`🛑 Stopping after page #${page}: it was entirely read`);
+      keepPaging = false;
+    } else if (toTime(oldestOnPage.indexedAt) < cutoff) {
+      logger.info(
+        `🕒 Stopping after page #${page}: reached notifications older than ${NOTIFICATION_LOOKBACK_DAYS} days`,
+      );
+      keepPaging = false;
+    } else if (!response.data.cursor) {
+      keepPaging = false;
+    } else {
+      cursor = response.data.cursor;
+    }
+  }
+
+  if (keepPaging && page === MAX_NOTIFICATION_PAGES) {
+    logger.warn(
+      `⚠️ Stopped at the ${MAX_NOTIFICATION_PAGES} page limit, there may be older unread notifications left`,
+    );
+  }
+
+  if (fetchedCount === 0) {
+    logger.info('❌ No notifications found');
+    return { mentions: [], latestIndexedAt: null };
+  }
+
+  logger.info(`📥 Fetched ${fetchedCount} notifications across ${page} page(s)`);
+  logger.info(`📤 Found ${mentions.length} unread mentions`);
+
+  return { mentions, latestIndexedAt };
+};
+
+// Marks notifications as read up to (and including) the given timestamp.
+// Always pass the `indexedAt` of a notification we actually fetched — using
+// "now" would mark anything that landed mid-run as read without us ever having
+// seen it, and those mentions would never get a reply.
+export const markNotificationsAsRead = async (agent: BskyAgent, seenAt: string) => {
   await agent.app.bsky.notification.updateSeen({
     seenAt,
   });

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -12,7 +12,11 @@ export type ProfanityDetails = {
 const prisma = new PrismaClient();
 
 /**
- * Store a new mention from a notification
+ * Store a new mention from a notification.
+ *
+ * Upserts on the unique postId so that replaying the same notification (a crash
+ * between storing and marking it read, or two overlapping runs) yields one row
+ * and one reply, and never resets a mention we've already replied to.
  */
 export async function storeMention({
   userHandle,
@@ -25,8 +29,11 @@ export async function storeMention({
   postUrl: string;
   isReply: boolean;
 }) {
-  return prisma.mention.create({
-    data: {
+  return prisma.mention.upsert({
+    where: { postId },
+    // We've already recorded this one, leave its status and reply alone
+    update: {},
+    create: {
       userHandle,
       postId,
       postUrl,

--- a/test/bluesky/get-mentions.test.ts
+++ b/test/bluesky/get-mentions.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BskyAgent } from '@atproto/api';
+import type { Notification } from '../../src/types.js';
+
+vi.mock('../../src/services/logger.js', () => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+// The bluesky service throws at import time without credentials
+process.env.BLUESKY_IDENTIFIER = process.env.BLUESKY_IDENTIFIER || 'test.bot';
+process.env.BLUESKY_PASSWORD = process.env.BLUESKY_PASSWORD || 'test-password';
+
+const { getMentions, markNotificationsAsRead } = await import('../../src/services/bluesky.js');
+
+type Page = Notification[];
+
+const makeNotification = (overrides: Partial<Notification>): Notification => ({
+  uri: 'at://did:plc:someone/app.bsky.feed.post/abc',
+  cid: 'bafycid',
+  author: {
+    did: 'did:plc:someone',
+    handle: 'someone.bsky.social',
+  },
+  reason: 'mention',
+  record: {},
+  isRead: false,
+  indexedAt: '2026-01-01T00:00:00.000Z',
+  labels: [],
+  ...overrides,
+} as unknown as Notification);
+
+// Pages are cursor-indexed, exactly like listNotifications: newest page first,
+// and the cursor points at the next page
+const makeAgent = (pages: Page[]) => {
+  const listNotifications = vi.fn(async ({ cursor }: { cursor?: string }) => {
+    const index = cursor ? Number(cursor) : 0;
+    const notifications = pages[index] ?? [];
+    const hasNextPage = index + 1 < pages.length;
+
+    return {
+      data: {
+        notifications,
+        cursor: hasNextPage ? String(index + 1) : undefined,
+      },
+    };
+  });
+
+  return { agent: { listNotifications } as unknown as BskyAgent, listNotifications };
+};
+
+describe('getMentions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops paginating after the first fully-read page', async () => {
+    const { agent, listNotifications } = makeAgent([
+      // Page 1: something unread, so we keep going
+      [
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/1', indexedAt: '2026-01-03T00:00:00.000Z' }),
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/2', indexedAt: '2026-01-02T23:00:00.000Z', isRead: true }),
+      ],
+      // Page 2: entirely read, so page 3 should never be requested
+      [
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/3', indexedAt: '2026-01-02T00:00:00.000Z', isRead: true }),
+      ],
+      // Page 3: unread, but older than a page we've already read through
+      [
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/4', indexedAt: '2026-01-01T00:00:00.000Z' }),
+      ],
+    ]);
+
+    const { mentions } = await getMentions(agent);
+
+    expect(listNotifications).toHaveBeenCalledTimes(2);
+    expect(mentions.map((mention) => mention.uri)).toEqual(['at://did:plc:a/app.bsky.feed.post/1']);
+  });
+
+  it('derives latestIndexedAt from the newest notification actually fetched', async () => {
+    const { agent } = makeAgent([
+      [
+        // A newer, already-read like still sets the ceiling for seenAt
+        makeNotification({ reason: 'like', isRead: true, indexedAt: '2026-01-05T12:00:00.000Z' }),
+        makeNotification({ indexedAt: '2026-01-05T09:00:00.000Z' }),
+      ],
+      [
+        makeNotification({ isRead: true, indexedAt: '2026-01-04T00:00:00.000Z' }),
+      ],
+    ]);
+
+    const { latestIndexedAt } = await getMentions(agent);
+
+    expect(latestIndexedAt).toBe('2026-01-05T12:00:00.000Z');
+  });
+
+  it('returns only unread mentions', async () => {
+    const { agent } = makeAgent([
+      [
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/unread-mention' }),
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/read-mention', isRead: true }),
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/unread-like', reason: 'like' }),
+        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/unread-reply', reason: 'reply' }),
+      ],
+    ]);
+
+    const { mentions } = await getMentions(agent);
+
+    expect(mentions.map((mention) => mention.uri)).toEqual(['at://did:plc:a/app.bsky.feed.post/unread-mention']);
+  });
+
+  it('stops paginating once notifications are older than the lookback window', async () => {
+    const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const { agent, listNotifications } = makeAgent([
+      [makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/old', indexedAt: longAgo })],
+      [makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/older', indexedAt: longAgo })],
+    ]);
+
+    await getMentions(agent);
+
+    expect(listNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nothing to mark as read when there are no notifications', async () => {
+    const { agent } = makeAgent([[]]);
+
+    const { mentions, latestIndexedAt } = await getMentions(agent);
+
+    expect(mentions).toEqual([]);
+    expect(latestIndexedAt).toBeNull();
+  });
+});
+
+describe('markNotificationsAsRead', () => {
+  it('marks notifications read up to the timestamp it is given, not "now"', async () => {
+    const updateSeen = vi.fn();
+    const agent = {
+      app: { bsky: { notification: { updateSeen } } },
+    } as unknown as BskyAgent;
+
+    await markNotificationsAsRead(agent, '2026-01-05T12:00:00.000Z');
+
+    expect(updateSeen).toHaveBeenCalledWith({ seenAt: '2026-01-05T12:00:00.000Z' });
+  });
+});

--- a/test/bluesky/get-mentions.test.ts
+++ b/test/bluesky/get-mentions.test.ts
@@ -2,40 +2,47 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { BskyAgent } from '@atproto/api';
 import type { Notification } from '../../src/types.js';
 
-vi.mock('../../src/services/logger.js', () => ({
-  info: vi.fn(),
-  success: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
+vi.mock(import('../../src/services/logger.js'), () => ({
+  info: vi.fn<() => void>(),
+  success: vi.fn<() => void>(),
+  warn: vi.fn<() => void>(),
+  error: vi.fn<() => void>(),
 }));
 
 // The bluesky service throws at import time without credentials
-process.env.BLUESKY_IDENTIFIER = process.env.BLUESKY_IDENTIFIER || 'test.bot';
-process.env.BLUESKY_PASSWORD = process.env.BLUESKY_PASSWORD || 'test-password';
+process.env.BLUESKY_IDENTIFIER ||= 'test.bot';
+process.env.BLUESKY_PASSWORD ||= 'test-password';
 
 const { getMentions, markNotificationsAsRead } = await import('../../src/services/bluesky.js');
 
 type Page = Notification[];
 
-const makeNotification = (overrides: Partial<Notification>): Notification => ({
-  uri: 'at://did:plc:someone/app.bsky.feed.post/abc',
-  cid: 'bafycid',
-  author: {
-    did: 'did:plc:someone',
-    handle: 'someone.bsky.social',
-  },
-  reason: 'mention',
-  record: {},
-  isRead: false,
-  indexedAt: '2026-01-01T00:00:00.000Z',
-  labels: [],
-  ...overrides,
-} as unknown as Notification);
+const makeNotification = (overrides: Partial<Notification>): Notification =>
+  ({
+    uri: 'at://did:plc:someone/app.bsky.feed.post/abc',
+    cid: 'bafycid',
+    author: {
+      did: 'did:plc:someone',
+      handle: 'someone.bsky.social',
+    },
+    reason: 'mention',
+    record: {},
+    isRead: false,
+    indexedAt: '2026-01-01T00:00:00.000Z',
+    labels: [],
+    ...overrides,
+  }) as unknown as Notification;
+
+const hoursAgo = (hours: number) => new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
 
 // Pages are cursor-indexed, exactly like listNotifications: newest page first,
 // and the cursor points at the next page
 const makeAgent = (pages: Page[]) => {
-  const listNotifications = vi.fn(async ({ cursor }: { cursor?: string }) => {
+  const listNotifications = vi.fn<
+    (params: {
+      cursor?: string;
+    }) => Promise<{ data: { notifications: Notification[]; cursor?: string } }>
+  >(async ({ cursor }) => {
     const index = cursor ? Number(cursor) : 0;
     const notifications = pages[index] ?? [];
     const hasNextPage = index + 1 < pages.length;
@@ -60,40 +67,55 @@ describe('getMentions', () => {
     const { agent, listNotifications } = makeAgent([
       // Page 1: something unread, so we keep going
       [
-        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/1', indexedAt: '2026-01-03T00:00:00.000Z' }),
-        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/2', indexedAt: '2026-01-02T23:00:00.000Z', isRead: true }),
+        makeNotification({
+          uri: 'at://did:plc:a/app.bsky.feed.post/1',
+          indexedAt: hoursAgo(1),
+        }),
+        makeNotification({
+          uri: 'at://did:plc:a/app.bsky.feed.post/2',
+          indexedAt: hoursAgo(2),
+          isRead: true,
+        }),
       ],
       // Page 2: entirely read, so page 3 should never be requested
       [
-        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/3', indexedAt: '2026-01-02T00:00:00.000Z', isRead: true }),
+        makeNotification({
+          uri: 'at://did:plc:a/app.bsky.feed.post/3',
+          indexedAt: hoursAgo(3),
+          isRead: true,
+        }),
       ],
       // Page 3: unread, but older than a page we've already read through
       [
-        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/4', indexedAt: '2026-01-01T00:00:00.000Z' }),
+        makeNotification({
+          uri: 'at://did:plc:a/app.bsky.feed.post/4',
+          indexedAt: hoursAgo(4),
+        }),
       ],
     ]);
 
     const { mentions } = await getMentions(agent);
 
     expect(listNotifications).toHaveBeenCalledTimes(2);
-    expect(mentions.map((mention) => mention.uri)).toEqual(['at://did:plc:a/app.bsky.feed.post/1']);
+    expect(mentions.map((mention) => mention.uri)).toStrictEqual([
+      'at://did:plc:a/app.bsky.feed.post/1',
+    ]);
   });
 
   it('derives latestIndexedAt from the newest notification actually fetched', async () => {
+    const newest = hoursAgo(1);
     const { agent } = makeAgent([
       [
         // A newer, already-read like still sets the ceiling for seenAt
-        makeNotification({ reason: 'like', isRead: true, indexedAt: '2026-01-05T12:00:00.000Z' }),
-        makeNotification({ indexedAt: '2026-01-05T09:00:00.000Z' }),
+        makeNotification({ reason: 'like', isRead: true, indexedAt: newest }),
+        makeNotification({ indexedAt: hoursAgo(2) }),
       ],
-      [
-        makeNotification({ isRead: true, indexedAt: '2026-01-04T00:00:00.000Z' }),
-      ],
+      [makeNotification({ isRead: true, indexedAt: hoursAgo(3) })],
     ]);
 
     const { latestIndexedAt } = await getMentions(agent);
 
-    expect(latestIndexedAt).toBe('2026-01-05T12:00:00.000Z');
+    expect(latestIndexedAt).toBe(newest);
   });
 
   it('returns only unread mentions', async () => {
@@ -102,13 +124,18 @@ describe('getMentions', () => {
         makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/unread-mention' }),
         makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/read-mention', isRead: true }),
         makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/unread-like', reason: 'like' }),
-        makeNotification({ uri: 'at://did:plc:a/app.bsky.feed.post/unread-reply', reason: 'reply' }),
+        makeNotification({
+          uri: 'at://did:plc:a/app.bsky.feed.post/unread-reply',
+          reason: 'reply',
+        }),
       ],
     ]);
 
     const { mentions } = await getMentions(agent);
 
-    expect(mentions.map((mention) => mention.uri)).toEqual(['at://did:plc:a/app.bsky.feed.post/unread-mention']);
+    expect(mentions.map((mention) => mention.uri)).toStrictEqual([
+      'at://did:plc:a/app.bsky.feed.post/unread-mention',
+    ]);
   });
 
   it('stops paginating once notifications are older than the lookback window', async () => {
@@ -120,7 +147,7 @@ describe('getMentions', () => {
 
     await getMentions(agent);
 
-    expect(listNotifications).toHaveBeenCalledTimes(1);
+    expect(listNotifications).toHaveBeenCalledOnce();
   });
 
   it('reports nothing to mark as read when there are no notifications', async () => {
@@ -128,14 +155,14 @@ describe('getMentions', () => {
 
     const { mentions, latestIndexedAt } = await getMentions(agent);
 
-    expect(mentions).toEqual([]);
+    expect(mentions).toStrictEqual([]);
     expect(latestIndexedAt).toBeNull();
   });
 });
 
 describe('markNotificationsAsRead', () => {
   it('marks notifications read up to the timestamp it is given, not "now"', async () => {
-    const updateSeen = vi.fn();
+    const updateSeen = vi.fn<(args: { seenAt: string }) => void>();
     const agent = {
       app: { bsky: { notification: { updateSeen } } },
     } as unknown as BskyAgent;

--- a/test/database/store-mention.test.ts
+++ b/test/database/store-mention.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { upsert } = vi.hoisted(() => ({ upsert: vi.fn() }));
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: vi.fn(() => ({
+    mention: { upsert },
+  })),
+}));
+
+import { storeMention } from '../../src/services/database.js';
+
+describe('storeMention', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('upserts on postId so replaying a notification cannot create a second row', async () => {
+    const mention = {
+      userHandle: 'someone.bsky.social',
+      postId: 'abc123',
+      postUrl: 'at://did:plc:someone/app.bsky.feed.post/abc123',
+      isReply: false,
+    };
+
+    await storeMention(mention);
+    await storeMention(mention);
+
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(upsert).toHaveBeenCalledWith({
+      where: { postId: 'abc123' },
+      // A replay must not reset the status of a mention we've already replied to
+      update: {},
+      create: mention,
+    });
+  });
+});

--- a/test/database/store-mention.test.ts
+++ b/test/database/store-mention.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { upsert } = vi.hoisted(() => ({ upsert: vi.fn() }));
+const { upsert } = vi.hoisted(() => ({
+  upsert: vi.fn<(args: { where: unknown; update: unknown; create: unknown }) => Promise<unknown>>(),
+}));
 
-vi.mock('@prisma/client', () => ({
-  PrismaClient: vi.fn(() => ({
+vi.mock(import('@prisma/client'), () => ({
+  PrismaClient: vi.fn<() => { mention: { upsert: typeof upsert } }>(() => ({
     mention: { upsert },
   })),
 }));
 
-import { storeMention } from '../../src/services/database.js';
+const { storeMention } = await import('../../src/services/database.js');
 
-describe('storeMention', () => {
+describe(storeMention, () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/test/mentions.test.ts
+++ b/test/mentions.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BskyAgent } from '@atproto/api';
+import type { Notification } from '../src/types.js';
+
+vi.mock('../src/services/database.js', () => ({
+  storeMention: vi.fn(),
+}));
+
+vi.mock('../src/services/bluesky.js', () => ({
+  markNotificationsAsRead: vi.fn(),
+  getPost: vi.fn(),
+  getProfile: vi.fn(),
+}));
+
+vi.mock('../src/services/logger.js', () => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import * as db from '../src/services/database.js';
+import * as bsky from '../src/services/bluesky.js';
+import storeMentions from '../src/mentions.js';
+
+const agent = {} as BskyAgent;
+
+const makeMention = (id: string, indexedAt: string): Notification => ({
+  uri: `at://did:plc:someone/app.bsky.feed.post/${id}`,
+  cid: 'bafycid',
+  author: {
+    did: 'did:plc:someone',
+    handle: 'someone.bsky.social',
+  },
+  reason: 'mention',
+  record: {},
+  isRead: false,
+  indexedAt,
+  labels: [],
+} as unknown as Notification);
+
+describe('storeMentions', () => {
+  beforeEach(() => {
+    // Reset, not clear: these tests swap in their own storeMention implementations
+    vi.resetAllMocks();
+  });
+
+  it('marks notifications read up to the newest one fetched when everything stores', async () => {
+    const mentions = [
+      makeMention('2', '2026-01-02T00:00:00.000Z'),
+      makeMention('1', '2026-01-01T00:00:00.000Z'),
+    ];
+
+    await storeMentions(agent, mentions, '2026-01-02T06:00:00.000Z');
+
+    expect(db.storeMention).toHaveBeenCalledTimes(2);
+    // Oldest first, so the read cursor only ever moves over stored mentions
+    expect(vi.mocked(db.storeMention).mock.calls.map(([data]) => data.postId)).toEqual(['1', '2']);
+    expect(bsky.markNotificationsAsRead).toHaveBeenCalledWith(agent, '2026-01-02T06:00:00.000Z');
+  });
+
+  it('advances the read cursor only up to the last mention stored before a failure', async () => {
+    const mentions = [
+      makeMention('1', '2026-01-01T00:00:00.000Z'),
+      makeMention('2', '2026-01-02T00:00:00.000Z'),
+      makeMention('3', '2026-01-03T00:00:00.000Z'),
+    ];
+
+    vi.mocked(db.storeMention).mockImplementation(async ({ postId }) => {
+      if (postId === '2') {
+        throw new Error('💥 database is having a day');
+      }
+      return {} as any;
+    });
+
+    await storeMentions(agent, mentions, '2026-01-03T12:00:00.000Z');
+
+    // The failed mention (and the one after it) stay unread for the next run
+    expect(bsky.markNotificationsAsRead).toHaveBeenCalledWith(agent, '2026-01-01T00:00:00.000Z');
+  });
+
+  it('does not mark anything read when the oldest mention fails to store', async () => {
+    const mentions = [
+      makeMention('1', '2026-01-01T00:00:00.000Z'),
+      makeMention('2', '2026-01-02T00:00:00.000Z'),
+    ];
+
+    vi.mocked(db.storeMention).mockRejectedValue(new Error('💥 database is having a day'));
+
+    await storeMentions(agent, mentions, '2026-01-02T12:00:00.000Z');
+
+    expect(bsky.markNotificationsAsRead).not.toHaveBeenCalled();
+  });
+
+  it('still advances the read cursor when the batch had no mentions in it', async () => {
+    await storeMentions(agent, [], '2026-01-02T12:00:00.000Z');
+
+    expect(db.storeMention).not.toHaveBeenCalled();
+    expect(bsky.markNotificationsAsRead).toHaveBeenCalledWith(agent, '2026-01-02T12:00:00.000Z');
+  });
+
+  it('does nothing when no notifications were fetched at all', async () => {
+    await storeMentions(agent, [], null);
+
+    expect(bsky.markNotificationsAsRead).not.toHaveBeenCalled();
+  });
+});

--- a/test/mentions.test.ts
+++ b/test/mentions.test.ts
@@ -2,44 +2,45 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { BskyAgent } from '@atproto/api';
 import type { Notification } from '../src/types.js';
 
-vi.mock('../src/services/database.js', () => ({
-  storeMention: vi.fn(),
+vi.mock(import('../src/services/database.js'), () => ({
+  storeMention: vi.fn<(mention: { userHandle: string; postId: string }) => Promise<unknown>>(),
 }));
 
-vi.mock('../src/services/bluesky.js', () => ({
-  markNotificationsAsRead: vi.fn(),
-  getPost: vi.fn(),
-  getProfile: vi.fn(),
+vi.mock(import('../src/services/bluesky.js'), () => ({
+  markNotificationsAsRead: vi.fn<(agent: unknown, seenAt: string) => Promise<void>>(),
+  getPost: vi.fn<() => void>(),
+  getProfile: vi.fn<() => void>(),
 }));
 
-vi.mock('../src/services/logger.js', () => ({
-  info: vi.fn(),
-  success: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
+vi.mock(import('../src/services/logger.js'), () => ({
+  info: vi.fn<() => void>(),
+  success: vi.fn<() => void>(),
+  warn: vi.fn<() => void>(),
+  error: vi.fn<() => void>(),
 }));
 
-import * as db from '../src/services/database.js';
-import * as bsky from '../src/services/bluesky.js';
-import storeMentions from '../src/mentions.js';
+const db = await import('../src/services/database.js');
+const bsky = await import('../src/services/bluesky.js');
+const { default: storeMentions } = await import('../src/mentions.js');
 
 const agent = {} as BskyAgent;
 
-const makeMention = (id: string, indexedAt: string): Notification => ({
-  uri: `at://did:plc:someone/app.bsky.feed.post/${id}`,
-  cid: 'bafycid',
-  author: {
-    did: 'did:plc:someone',
-    handle: 'someone.bsky.social',
-  },
-  reason: 'mention',
-  record: {},
-  isRead: false,
-  indexedAt,
-  labels: [],
-} as unknown as Notification);
+const makeMention = (id: string, indexedAt: string): Notification =>
+  ({
+    uri: `at://did:plc:someone/app.bsky.feed.post/${id}`,
+    cid: 'bafycid',
+    author: {
+      did: 'did:plc:someone',
+      handle: 'someone.bsky.social',
+    },
+    reason: 'mention',
+    record: {},
+    isRead: false,
+    indexedAt,
+    labels: [],
+  }) as unknown as Notification;
 
-describe('storeMentions', () => {
+describe(storeMentions, () => {
   beforeEach(() => {
     // Reset, not clear: these tests swap in their own storeMention implementations
     vi.resetAllMocks();
@@ -55,7 +56,10 @@ describe('storeMentions', () => {
 
     expect(db.storeMention).toHaveBeenCalledTimes(2);
     // Oldest first, so the read cursor only ever moves over stored mentions
-    expect(vi.mocked(db.storeMention).mock.calls.map(([data]) => data.postId)).toEqual(['1', '2']);
+    expect(vi.mocked(db.storeMention).mock.calls.map(([data]) => data.postId)).toStrictEqual([
+      '1',
+      '2',
+    ]);
     expect(bsky.markNotificationsAsRead).toHaveBeenCalledWith(agent, '2026-01-02T06:00:00.000Z');
   });
 


### PR DESCRIPTION
Fixes #11.

## What was wrong

1. **Mentions could be silently lost.** `markNotificationsAsRead()` called `updateSeen({ seenAt: new Date().toISOString() })` — "now". Anything arriving between `listNotifications` and `updateSeen` got marked read without ever being fetched, and the next run skipped it because `isRead` was true. No reply, no DB row, no trace.
2. **Mentions could be double-processed.** No unique constraint on `Mention.postId`, so a crash between `storeMention()` and `updateSeen` (or two overlapping cron runs) stored the same notification twice and replied twice.
3. **Every run paginated the account's entire notification history**, then filtered for unread in memory.

## What changed

**`src/services/bluesky.ts`**
- `getMentions()` now returns `{ mentions, latestIndexedAt }`, where `latestIndexedAt` is the newest `indexedAt` across everything we actually fetched (including likes/follows, so the read cursor stays current and pagination stays cheap).
- Pagination stops at the first page where every notification is already read — they come back newest-first, so everything older has been seen too. Backstops: a 7 day lookback and a 25 page cap, both logged when hit.
- `markNotificationsAsRead(agent, seenAt)` takes the timestamp explicitly. There is no longer a code path that can pass "now".

**`src/mentions.ts`**
- Mentions are processed **sequentially, oldest first** (the comment already claimed sequential; the code ran `Promise.all` with unbounded concurrency).
- The read cursor only advances over mentions that were actually persisted. On a store failure, `seenAt` is pinned to the last successfully stored mention *strictly older* than the failure, so the failed one — and everything after it — stays unread and is retried next run. If the oldest mention fails, nothing is marked read at all.
- Per-mention errors go through the logger instead of `console.error`.

**`src/services/database.ts` + `prisma/schema.prisma`**
- `@@unique([postId])` on `Mention`, and `storeMention()` is now an `upsert` with `update: {}` — replaying a notification is a no-op and can't reset a mention that's already `DONE`. This is what makes the "leave it unread and retry" behaviour above safe.

**`src/index.ts`**
- Passes the batch through to `storeMentions()`, and now advances the read cursor even when a run fetched notifications but no new mentions.

## Deploy note ⚠️

The schema change is not applied by CI (the workflows only run `prisma:generate`), so `pnpm db:push` needs to be run against the database as part of rolling this out. **If the `Mention` table already contains duplicate `postId` rows, the unique index will fail to create** — dedupe first, keeping the oldest row per `postId`:

```sql
DELETE FROM "Mention" a USING "Mention" b
WHERE a."postId" = b."postId" AND a."createdAt" > b."createdAt";
```

## Tests

Added `test/bluesky/get-mentions.test.ts`, `test/mentions.test.ts`, and `test/database/store-mention.test.ts` covering each acceptance criterion: the 3-page mocked feed stopping after page 2, `latestIndexedAt` coming from the batch, `seenAt` pass-through, the store-failure retry cases, and the upsert keyed on `postId`.

**These have not been run.** npm registry access is blocked in this environment (403 on both metadata and tarballs), so dependencies couldn't be installed — the changed files are syntax-checked only. Worth a local `pnpm test` before taking this out of draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ES4LMawxGQVmtGgaiYsMNU)_